### PR TITLE
Update btcd.conf to use ports used by Peercoin

### DIFF
--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -163,16 +163,16 @@
 ;   rpclisten=0.0.0.0
 ; All ipv6 interfaces on default port:
 ;   rpclisten=::
-; All interfaces on port 8334:
-;   rpclisten=:8334
-; All ipv4 interfaces on port 8334:
-;   rpclisten=0.0.0.0:8334
-; All ipv6 interfaces on port 8334:
-;   rpclisten=[::]:8334
-; Only ipv4 localhost on port 8334:
-;   rpclisten=127.0.0.1:8334
-; Only ipv6 localhost on port 8334:
-;   rpclisten=[::1]:8334
+; All interfaces on port 9902:
+;   rpclisten=:9902
+; All ipv4 interfaces on port 9902:
+;   rpclisten=0.0.0.0:9902
+; All ipv6 interfaces on port 9902:
+;   rpclisten=[::]:9902
+; Only ipv4 localhost on port 9902:
+;  rpclisten=127.0.0.1:9902
+; Only ipv6 localhost on port 9902:
+;   rpclisten=[::1]:9902
 ; Only ipv4 localhost on non-standard port 8337:
 ;   rpclisten=127.0.0.1:8337
 ; All interfaces on non-standard port 8337:


### PR DESCRIPTION
Peercoin protocol used ports 9902.
